### PR TITLE
build: upgrade third-party GitHub Actions to latest tags

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
           repository: grafana/grafana-github-actions

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -17,10 +17,10 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.21'
           

--- a/.github/workflows/config-checker.yml
+++ b/.github/workflows/config-checker.yml
@@ -17,11 +17,11 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: actions/checkout@v6.0.2 # v4
       with:
         persist-credentials: 'false'
     - name: Set up Go
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      uses: actions/setup-go@v6.4.0 # v5
       with:
         go-version-file: 'go.mod'
         cache: false  # Disable caching to avoid extraction conflicts
@@ -65,7 +65,7 @@ jobs:
 
     - name: Manage issues
       if: always() # Always run this step to ensure proper issue management
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+      uses: actions/github-script@v8 # v7
       with:
         script: |
           // Find if there's an existing issue

--- a/.github/workflows/generate-binaries.yml
+++ b/.github/workflows/generate-binaries.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
           fetch-depth: 0

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
           fetch-depth: 0 # required for chart-testing to work
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Set up Linting with chart-testing
-        uses: helm/chart-testing-action@5f16c27cf7a4fa9c776ff73734df3909b2b65127 # v2.1.0
+        uses: helm/chart-testing-action@v2.8.0 # v2.1.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -66,7 +66,7 @@ jobs:
       tests: ${{ steps.list_tests.outputs.tests }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
 
@@ -91,31 +91,31 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@v6.0.2  # v4.2.2
         with:
           path: source
           persist-credentials: 'false'
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@v6.0.2  # v4.2.2
         with:
           path: helm-chart-toolbox
           repository: grafana/helm-chart-toolbox
           persist-credentials: 'false'
 
       - name: Set up Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
+        uses: azure/setup-helm@v5.0.0  # v4.3.0
 
       - name: Install Flux CLI
-        uses: fluxcd/flux2/action@6bf37f6a560fd84982d67f853162e4b3c2235edb  # v2.6.4
+        uses: fluxcd/flux2/action@v2.8.5  # v2.6.4
 
       - name: Install Kind CLI
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1.12.0
+        uses: helm/kind-action@v1.14.0  # v1.12.0
         with:
           install_only: true
 
       - name: Install Minikube CLI
-        uses: medyagh/setup-minikube@e3c7f79eb1e997eabccc536a6cf318a2b0fe19d9  # v0.0.20
+        uses: medyagh/setup-minikube@v0.0.21  # v0.0.20
         with:
           start: false
 

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -20,9 +20,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/publish-technical-documentation@39cdc38767184996e25d611923f8ce697e33bc70 # publish-technical-documentation/v1
+      - uses: grafana/writers-toolkit/publish-technical-documentation@vale/v1.0.0 # publish-technical-documentation/v1
         with:
           website_directory: content/docs/beyla/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           fetch-depth: 0
           persist-credentials: 'false'

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - id: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
       - id: push-beyla-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@issues-update-project-status/v0.1.0 # main
         with:
           repository: grafana/beyla
           context: .
@@ -31,7 +31,7 @@ jobs:
           push: true
 
       - id: push-beyla-k8s-cache-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@issues-update-project-status/v0.1.0 # main
         with:
           repository: grafana/beyla-k8s-cache
           file: k8scache.Dockerfile

--- a/.github/workflows/publish_dockerhub_release.yml
+++ b/.github/workflows/publish_dockerhub_release.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - id: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
       - id: push-beyla-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@issues-update-project-status/v0.1.0 # main
         with:
           repository: grafana/beyla
           context: .
@@ -33,7 +33,7 @@ jobs:
           push: true
 
       - id: push-beyla-k8s-cache-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@issues-update-project-status/v0.1.0 # main
         with:
           repository: grafana/beyla-k8s-cache
           file: k8scache.Dockerfile

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         go: [ '1.24' ]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@v6.4.0 # v3
         with:
           cache: false  # Disable caching to avoid extraction conflicts
           go-version: ${{ matrix.go }}
@@ -42,7 +42,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@v6.0.0 # v4
         continue-on-error: true
         with:
           file: ./testoutput/cover.txt

--- a/.github/workflows/pull_request_check_license.yml
+++ b/.github/workflows/pull_request_check_license.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         go: [ '1.24' ]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@v6.4.0 # v3
         with:
           cache: 'false'
           go-version: ${{ matrix.go }}

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         go: [ '1.24' ]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        uses: actions/setup-go@v6.4.0 # v5
         with:
           cache: false  # Disable caching to avoid extraction conflicts
           go-version: ${{ matrix.go }}
@@ -40,7 +40,7 @@ jobs:
         run: make docker-generate integration-test
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7.0.0 # v4
         if: always()
         with:
           name: Test Logs
@@ -55,7 +55,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@v6.0.0 # v4
         continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         go: [ '1.24' ]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@v6.4.0 # v3
         with:
           cache: false  # Disable caching to avoid extraction conflicts
           go-version: ${{ matrix.go }}
@@ -40,7 +40,7 @@ jobs:
         run: make docker-generate integration-test-arm
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7.0.0 # v4
         if: always()
         with:
           name: Test Logs
@@ -55,7 +55,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@v6.0.0 # v4
         continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -24,11 +24,11 @@ jobs:
       matrix:
         go: [ '1.24' ]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@v6.4.0 # v3
         with:
           cache: false  # Disable caching to avoid extraction conflicts
           go-version: ${{ matrix.go }}
@@ -40,7 +40,7 @@ jobs:
         run: make docker-generate integration-test-k8s
         timeout-minutes: 60
       - name: Upload integration test logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7.0.0 # v4
         if: always()
         with:
           name: K8s test Logs
@@ -55,7 +55,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@v6.0.0 # v4
         continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -20,11 +20,11 @@ jobs:
       # required for CODECOV token
       id-token: write
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@v6.4.0 # v3
         with:
           cache: false  # Disable caching to avoid extraction conflicts
           go-version: ${{ matrix.go }}
@@ -35,7 +35,7 @@ jobs:
       - name: Run oats tests
         run: make oats-test
       - name: Upload oats test logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7.0.0 # v4
         if: always()
         with:
           name: Oats test logs
@@ -48,7 +48,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@v6.0.0 # v4
         continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt

--- a/.github/workflows/pull_request_test_docker_build.yml
+++ b/.github/workflows/pull_request_test_docker_build.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - id: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
       - id: docker-build-beyla
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@issues-update-project-status/v0.1.0 # main
         with:
           context: .
           platforms: |-
@@ -27,7 +27,7 @@ jobs:
           push: false
 
       - id: docker-build-cache
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@fa48192dac470ae356b3f7007229f3ac28c48a25 # main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@issues-update-project-status/v0.1.0 # main
         with:
           repository: grafana/beyla-k8s-cache
           file: k8scache.Dockerfile

--- a/.github/workflows/release-binaries-base.yml
+++ b/.github/workflows/release-binaries-base.yml
@@ -22,11 +22,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@v6.4.0 # v3
         with:
           cache: false  # Disable caching to avoid extraction conflicts
           go-version: ${{ matrix.go }}
@@ -36,7 +36,7 @@ jobs:
           GOOS: linux
           GOARCH: ${{ inputs.arch }}
       - name: Upload release asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
+        uses: actions/upload-release-asset@v1.0.2 # v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/restart-noteldemo.yml
+++ b/.github/workflows/restart-noteldemo.yml
@@ -29,7 +29,7 @@ jobs:
             EKS_CLUSTER_NAME=noteldemo:eks-cluster-name
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        uses: aws-actions/configure-aws-credentials@v6.1.0 # v4
         with:
           role-to-assume: ${{ fromJSON(steps.get-vault-secrets.outputs.secrets).AWS_ROLE_ARN }}
           role-session-name: beyla-demo-restart

--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write  # Needed for creating commits or PRs
       pull-requests: write  # Needed if the action creates PRs
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v6.0.2 # v4
         with:
           persist-credentials: 'false'
-      - uses: grafana/writers-toolkit/update-make-docs@f65819d6a412b752c0e0263375215f049507b0e6 # update-make-docs/v1
+      - uses: grafana/writers-toolkit/update-make-docs@vale/v1.0.0 # update-make-docs/v1

--- a/.github/workflows/update-offsets.yml
+++ b/.github/workflows/update-offsets.yml
@@ -17,11 +17,11 @@ jobs:
       pull-requests: write  # Needed for creating PRs
     steps:
     - name: "Checkout repo"
-      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      uses: actions/checkout@v6.0.2 # v3
       with:
         persist-credentials: false
     - name: "Update Go"
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+      uses: actions/setup-go@v6.4.0 # v5
       with:
         cache: false  # Disable caching to avoid extraction conflicts
         go-version: '>=1.24'
@@ -29,7 +29,7 @@ jobs:
     - name: "Update offsets"
       run: make update-offsets
     - name: "Create/update PR"
-      uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
+      uses: peter-evans/create-pull-request@v8.1.0 # v5
       with:
         commit-message: Automatic update of offsets.json
         title: Automatic update of offsets.json

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -14,9 +14,9 @@ jobs:
     container:
       image: grafana/vale@sha256:5eded74785e98384d84878073d5d41125b2ad21f1d711b06ab214c7890a81a19
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v6.0.2 # v4.2.2
         with:
           persist-credentials: false
-      - uses: grafana/writers-toolkit/vale-action@1dd3173b59e3128c9d74645c4684a7b57aadbb77 # vale-action/v1
+      - uses: grafana/writers-toolkit/vale-action@vale/v1.0.0 # vale-action/v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         go: [ '1.24' ]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v6.0.2 # v3
         with:
           persist-credentials: 'false'
       - name: Clean up disk space
@@ -44,7 +44,7 @@ jobs:
           ARCH: ${{ inputs.arch }}
         timeout-minutes: ${{ inputs.timeout-minutes }}
       - name: Upload integration test logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7.0.0 # v4
         if: always()
         with:
           name: Test Logs
@@ -59,7 +59,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=codecov:token
       - name: Report coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@v6.0.0 # v4
         continue-on-error: true
         with:
           file: ./testoutput/itest-covdata.txt


### PR DESCRIPTION
Automated bump of marketplace/public actions. Floating major pins (e.g. `v6`) are left as-is when the API reports a newer patch on the same major; cross-major upgrades use a floating major (`v6`) rather than a specific patch. Reusable workflow calls and branch pins are unchanged. Review CI before merge.